### PR TITLE
By default attempt to use the local service account

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GO=CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go
-TAG=v1.1.4
+TAG=v1.1.5
 BIN=route53-kubernetes
 IMAGE=quay.io/molecule/$(BIN)
 

--- a/service_listener.go
+++ b/service_listener.go
@@ -27,11 +27,8 @@ func main() {
 	flag.Parse()
 	glog.Info("Route53 Update Service")
 	
-	var config restclient.Config
-	clusterConfig, err := restclient.InClusterConfig()
-	if err == nil {
-		config = *clusterConfig
-	} else {
+	config, err := restclient.InClusterConfig()
+	if err != nil {
 		kubernetesService := os.Getenv("KUBERNETES_SERVICE_HOST")
 		kubernetesServicePort := os.Getenv("KUBERNETES_SERVICE_PORT")
 		if kubernetesService == "" {
@@ -60,13 +57,13 @@ func main() {
 			glog.Fatalf("Couldn't set up tls transport: %s", err)
 		}
 	
-		config = restclient.Config{
+		config = &restclient.Config{
 			Host:      apiServer,
 			Transport: tlsTransport,
 		}
 	}
 
-	c, err := client.New(&config)
+	c, err := client.New(config)
 	if err != nil {
 		glog.Fatalf("Failed to make client: %v", err)
 	}

--- a/service_listener.go
+++ b/service_listener.go
@@ -26,44 +26,51 @@ import (
 func main() {
 	flag.Parse()
 	glog.Info("Route53 Update Service")
-	kubernetesService := os.Getenv("KUBERNETES_SERVICE_HOST")
-	kubernetesServicePort := os.Getenv("KUBERNETES_SERVICE_PORT")
-	if kubernetesService == "" {
-		glog.Fatal("Please specify the Kubernetes server via KUBERNETES_SERVICE_HOST")
-	}
-	if kubernetesServicePort == "" {
-		kubernetesServicePort = "443"
-	}
-	apiServer := fmt.Sprintf("https://%s:%s", kubernetesService, kubernetesServicePort)
-
-	caFilePath := os.Getenv("CA_FILE_PATH")
-	certFilePath := os.Getenv("CERT_FILE_PATH")
-	keyFilePath := os.Getenv("KEY_FILE_PATH")
-	if caFilePath == "" || certFilePath == "" || keyFilePath == "" {
-		glog.Fatal("You must provide paths for CA, Cert, and Key files")
-	}
-
-	tls := transport.TLSConfig{
-		CAFile:   caFilePath,
-		CertFile: certFilePath,
-		KeyFile:  keyFilePath,
-	}
-	// tlsTransport := transport.New(transport.Config{TLS: tls})
-	tlsTransport, err := transport.New(&transport.Config{TLS: tls})
-	if err != nil {
-		glog.Fatalf("Couldn't set up tls transport: %s", err)
-	}
-
-	config := restclient.Config{
-		Host:      apiServer,
-		Transport: tlsTransport,
+	
+	var config restclient.Config
+	clusterConfig, err := restclient.InClusterConfig()
+	if err == nil {
+		config = *clusterConfig
+	} else {
+		kubernetesService := os.Getenv("KUBERNETES_SERVICE_HOST")
+		kubernetesServicePort := os.Getenv("KUBERNETES_SERVICE_PORT")
+		if kubernetesService == "" {
+			glog.Fatal("Please specify the Kubernetes server via KUBERNETES_SERVICE_HOST")
+		}
+		if kubernetesServicePort == "" {
+			kubernetesServicePort = "443"
+		}
+		apiServer := fmt.Sprintf("https://%s:%s", kubernetesService, kubernetesServicePort)
+	
+		caFilePath := os.Getenv("CA_FILE_PATH")
+		certFilePath := os.Getenv("CERT_FILE_PATH")
+		keyFilePath := os.Getenv("KEY_FILE_PATH")
+		if caFilePath == "" || certFilePath == "" || keyFilePath == "" {
+			glog.Fatal("You must provide paths for CA, Cert, and Key files")
+		}
+	
+		tls := transport.TLSConfig{
+			CAFile:   caFilePath,
+			CertFile: certFilePath,
+			KeyFile:  keyFilePath,
+		}
+		// tlsTransport := transport.New(transport.Config{TLS: tls})
+		tlsTransport, err := transport.New(&transport.Config{TLS: tls})
+		if err != nil {
+			glog.Fatalf("Couldn't set up tls transport: %s", err)
+		}
+	
+		config = restclient.Config{
+			Host:      apiServer,
+			Transport: tlsTransport,
+		}
 	}
 
 	c, err := client.New(&config)
 	if err != nil {
 		glog.Fatalf("Failed to make client: %v", err)
 	}
-	glog.Infof("Connected to kubernetes @ %s", apiServer)
+	glog.Infof("Connected to kubernetes @ %s", config.Host)
 
 	metadata := ec2metadata.New(session.New())
 


### PR DESCRIPTION
This change causes the script to load restclient.InClusterConfig which uses the local service account, falling back to the manually configured connection parameters only if necessary. With this change, documentation and configuration could be simplified in the common case. 
