### PR TITLE
allow TLDs in annotations

### DIFF
--- a/service_listener.go
+++ b/service_listener.go
@@ -164,7 +164,7 @@ func main() {
 			zoneParts := strings.Split(zoneID, "/")
 			zoneID = zoneParts[len(zoneParts)-1]
 
-			if err = updateDNS(r53Api, hn, hzID, domain, zoneID); err != nil {
+			if err = updateDNS(r53Api, hn, hzID, strings.TrimLeft(domain, "."), zoneID); err != nil {
 				glog.Warning(err)
 				continue
 			}


### PR DESCRIPTION
This change allows you to set top-level domains in annotations, using, eg ".user.me"
