### PR TITLE
Fix domain suffix bug

### DIFF
--- a/service_listener.go
+++ b/service_listener.go
@@ -222,7 +222,7 @@ func findMostSpecificZoneForDomain(domain string, zones []*route53.HostedZone) (
 		zone := zones[i]
 		zoneName := *zone.Name
 
-		if strings.HasSuffix(domain, zoneName) && curLen < len(zoneName) {
+		if strings.HasSuffix(domain, "." + zoneName) && curLen < len(zoneName) {
 			curLen = len(zoneName)
 			mostSpecific = zone
 		}


### PR DESCRIPTION
Fixing domain matching bug to avoid some unrelated domain with almost similar name treated as a child.

e.g. abc-test.example.com should not be treated as a child of test.example.com,
 and abc.test.example.com should be treated as a child of test.example.com