### PR TITLE
Target Health Evaluation annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ An "A" record for `test.mydomain.com` will be created as an alias to the ELB tha
 configured by kubernetes. This assumes that a hosted zone exists in Route53 for mydomain.com.
 Any record that previously existed for that dns record will be updated.
 
+#### Evaluating target health
+
+Target Health Evaluation by Route 53 can be enabled by adding an `evaluateTargetHealth=true` annotation. Please note that
+if you have specified multiple domains with the `domainName` annotation, target health evaluation will be enabled for
+each record created.
+
 
 ### Alternative setup
 


### PR DESCRIPTION
This PR adds support for enabling Target Health Evaluation through an annotation on the service. Adding `targetHealthEvaluation=true` as an annotation will create records with target health evaluation set to true.

_Side note_: I think these annotations are a bit ambiguous. I think that the annotations should be namespaced. I think the following would be good:

`route53.amazonaws.com/recordName=myrecord.example.com`
`route53.amazonaws.com/evaluateTargetHealth=true`

What do you think? If you agree I can update this PR, or create a new one if you'd like. Let me know.

Thanks!