### PR TITLE
ELBHostname annotation

### DIFF
--- a/service_listener.go
+++ b/service_listener.go
@@ -252,6 +252,9 @@ func domainWithTrailingDot(withoutDot string) string {
 }
 
 func serviceHostname(service *api.Service) (string, error) {
+        if ! len(service.ObjectMeta.Annotations["ELBHostname"]) == 0 {
+           return service.ObjectMeta.Annotations["ELBHostname"], nil
+        }
 	ingress := service.Status.LoadBalancer.Ingress
 	if len(ingress) < 1 {
 		return "", errors.New("No ingress defined for ELB")

--- a/service_listener.go
+++ b/service_listener.go
@@ -252,8 +252,10 @@ func domainWithTrailingDot(withoutDot string) string {
 }
 
 func serviceHostname(service *api.Service) (string, error) {
-        if ! len(service.ObjectMeta.Annotations["ELBHostname"]) == 0 {
-           return service.ObjectMeta.Annotations["ELBHostname"], nil
+        if service.ObjectMeta.Annotations["ELBHostname"] {
+          if ! len(service.ObjectMeta.Annotations["ELBHostname"]) == 0 {
+            return service.ObjectMeta.Annotations["ELBHostname"], nil
+          }
         }
 	ingress := service.Status.LoadBalancer.Ingress
 	if len(ingress) < 1 {

--- a/service_listener.go
+++ b/service_listener.go
@@ -252,8 +252,9 @@ func domainWithTrailingDot(withoutDot string) string {
 }
 
 func serviceHostname(service *api.Service) (string, error) {
-        if service.ObjectMeta.Annotations["ELBHostname"] {
-          if ! len(service.ObjectMeta.Annotations["ELBHostname"]) == 0 {
+        _, isset := service.ObjectMeta.Annotations["ELBHostname"]
+        if isset {
+          if len(service.ObjectMeta.Annotations["ELBHostname"]) > 0 {
             return service.ObjectMeta.Annotations["ELBHostname"], nil
           }
         }


### PR DESCRIPTION
We use traefik as loadbalancer inside kubernetes, with a kubernetes service `LoadBalancer`-type. Then traefik configures itself with kubernetes Ingresses because of `kubernetes` as backend.

Well, I've started to use this addon but it searches for `.status.LoadBalancer.Hostname`. 
The proposal is to get an annotation to customize/force which ELB will be used for that dns entry. That means that I have a known ELB directed to traefik and I will point any DomainName to that load balancer.
The PR adds a match for `ELBHostname` annotation and returns it if is defined.

This is a proposal and may get tagged as WIP.